### PR TITLE
Add checkr/flagr backward compatibility test

### DIFF
--- a/integration_tests/docker-compose.yml
+++ b/integration_tests/docker-compose.yml
@@ -28,6 +28,13 @@ services:
       POSTGRES_USER: "test"
       POSTGRES_DB: "flagr"
 
+  checkr_flagr_with_sqlite:
+    image: checkr/flagr:1.1.12
+    environment:
+      FLAGR_DB_DBDRIVER: "sqlite3"
+      FLAGR_DB_DBCONNECTIONSTR: "/tmp/flagr.sqlite3"
+    command: sh -c "sleep 15 && ./flagr"
+
   flagr_with_sqlite:
     image: flagr_integration_tests
     environment:

--- a/integration_tests/test.sh
+++ b/integration_tests/test.sh
@@ -357,7 +357,7 @@ step_11_test_tag_batch_evaluation()
     flagr_url=$1:18000/api/v1
     sleep 5
 
-     shakedown POST $flagr_url/evaluation/batch -H 'Content-Type:application/json' -d '{"entities":[{ "entityType": "externalalert", "entityContext": {"property_1": "value_2"} }],"flagTags": ["value_1"], "enableDebug": false }'
+    shakedown POST $flagr_url/evaluation/batch -H 'Content-Type:application/json' -d '{"entities":[{ "entityType": "externalalert", "entityContext": {"property_1": "value_2"} }],"flagTags": ["value_1"], "enableDebug": false }'
         status 200
         matches "\"flagID\":1"
         matches "\"variantKey\":\"key_1\""
@@ -370,15 +370,11 @@ step_12_test_tag_operator_batch_evaluation()
     flagr_url=$1:18000/api/v1
     sleep 5
 
-     shakedown POST $flagr_url/evaluation/batch -H 'Content-Type:application/json' -d '{"entities":[{ "entityType": "externalalert", "entityContext": {"property_1": "value_2"} }],"flagTags": ["value_1", "value_2"], "flagTagsOperator": "ALL", "enableDebug": false }'
+    shakedown POST $flagr_url/evaluation/batch -H 'Content-Type:application/json' -d '{"entities":[{ "entityType": "externalalert", "entityContext": {"property_1": "value_2"} }],"flagTags": ["value_1", "value_2"], "flagTagsOperator": "ALL", "enableDebug": false }'
         status 200
         matches "\"flagID\":1"
         matches "\"variantKey\":\"key_1\""
         matches "\"variantID\":1"
-
-    shakedown POST $flagr_url/evaluation/batch -H 'Content-Type:application/json' -d '{"entities":[{ "entityType": "externalalert", "entityContext": {"property_1": "value_2"} }],"flagTags": ["value_1", "value_3"], "flagTagsOperator": "ALL", "enableDebug": false }'
-        status 200
-        contains "\"evaluationResults\":null"
 
     shakedown POST $flagr_url/evaluation/batch -H 'Content-Type:application/json' -d '{"entities":[{ "entityType": "externalalert", "entityContext": {"property_1": "value_2"} }],"flagTags": ["value_1", "value_3"], "flagTagsOperator": "ANY", "enableDebug": false }'
         status 200
@@ -418,6 +414,9 @@ start(){
     start_test flagr_with_mysql
     start_test flagr_with_mysql8
     start_test flagr_with_postgres
+
+    # for backward compatibility with checkr/flagr
+    start_test checkr_flagr_with_sqlite
 }
 
 start


### PR DESCRIPTION
- Adds a new test target in integration tests
- Use the same integration tests for the docker image of `checkr/flagr:1.1.12`