### PR TITLE
Add distribution threshold test

### DIFF
--- a/pkg/handler/eval_test.go
+++ b/pkg/handler/eval_test.go
@@ -1,9 +1,13 @@
 package handler
 
 import (
+	"fmt"
+	"math"
 	"testing"
 
+	"github.com/dchest/uniuri"
 	"github.com/openflagr/flagr/pkg/entity"
+	"github.com/openflagr/flagr/pkg/util"
 	"github.com/openflagr/flagr/swagger_gen/models"
 	"github.com/openflagr/flagr/swagger_gen/restapi/operations/evaluation"
 
@@ -351,6 +355,97 @@ func TestEvalFlag(t *testing.T) {
 			assert.NotEqual(t, "entityType1", result.EvalContext.EntityType)
 			assert.Equal(t, "some_entity_type", result.EvalContext.EntityType)
 		})
+	})
+}
+
+func TestEvalFlagDistribution(t *testing.T) {
+	defer gostub.StubFunc(&GetEvalCache, GenFixtureEvalCache()).Reset()
+
+	// vID1 and vID2 are the variants generated from GenFixtureEvalCache
+	vID1, vID2 := int64(300), int64(301)
+
+	// we are testing the `num` cases with the relative distribution differences between the two variants
+	// in this case, we set it to be 0.5% of 1e6 samples
+	num, threshold := int(1e6), 0.005
+
+	t.Run("test distribution on integers", func(t *testing.T) {
+		cnt := make(map[int64]int)
+		for i := 0; i < num; i++ {
+			result := EvalFlag(models.EvalContext{
+				EnableDebug:   false,
+				EntityContext: map[string]interface{}{"dl_state": "CA"},
+				EntityID:      fmt.Sprintf("%d", i),
+				EntityType:    "entityType1",
+				FlagID:        int64(100),
+			})
+			cnt[result.VariantID]++
+		}
+		assert.Len(t, cnt, 2)
+		assert.Less(t,
+			math.Abs(float64(cnt[vID1]-cnt[vID2])/float64(cnt[vID1]+cnt[vID2])),
+			threshold,
+			"Expected distribution to be uniform",
+		)
+	})
+
+	t.Run("test distribution on secure random key generator", func(t *testing.T) {
+		cnt := make(map[int64]int)
+		for i := 0; i < num; i++ {
+			result := EvalFlag(models.EvalContext{
+				EnableDebug:   false,
+				EntityContext: map[string]interface{}{"dl_state": "CA"},
+				EntityID:      util.NewSecureRandomKey(),
+				EntityType:    "entityType1",
+				FlagID:        int64(100),
+			})
+			cnt[result.VariantID]++
+		}
+		assert.Len(t, cnt, 2)
+		assert.Less(t,
+			math.Abs(float64(cnt[vID1]-cnt[vID2])/float64(cnt[vID1]+cnt[vID2])),
+			threshold,
+			"Expected distribution to be uniform",
+		)
+	})
+
+	t.Run("test distribution on uuid", func(t *testing.T) {
+		cnt := make(map[int64]int)
+		for i := 0; i < num; i++ {
+			result := EvalFlag(models.EvalContext{
+				EnableDebug:   false,
+				EntityContext: map[string]interface{}{"dl_state": "CA"},
+				EntityID:      uniuri.NewLen(uniuri.UUIDLen),
+				EntityType:    "entityType1",
+				FlagID:        int64(100),
+			})
+			cnt[result.VariantID]++
+		}
+		assert.Len(t, cnt, 2)
+		assert.Less(t,
+			math.Abs(float64(cnt[vID1]-cnt[vID2])/float64(cnt[vID1]+cnt[vID2])),
+			threshold,
+			"Expected distribution to be uniform",
+		)
+	})
+
+	t.Run("test distribution on random string + int", func(t *testing.T) {
+		cnt := make(map[int64]int)
+		for i := 0; i < num; i++ {
+			result := EvalFlag(models.EvalContext{
+				EnableDebug:   false,
+				EntityContext: map[string]interface{}{"dl_state": "CA"},
+				EntityID:      fmt.Sprintf("random_int%d%s", i, util.NewSecureRandomKey()),
+				EntityType:    "entityType1",
+				FlagID:        int64(100),
+			})
+			cnt[result.VariantID]++
+		}
+		assert.Len(t, cnt, 2)
+		assert.Less(t,
+			math.Abs(float64(cnt[vID1]-cnt[vID2])/float64(cnt[vID1]+cnt[vID2])),
+			threshold,
+			"Expected distribution to be uniform",
+		)
 	})
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
To make sure that the distribution result from eval flags are as close as expected with the hashing function that flagr is using (i.e. CRC32). In these tests, we are targeting 1e6 samples and a 0.5% error bar (usually it's less than 0.1%, e.g. 0.0436% from the secure random key generator, but for reducing the flakiness of unit tests, we are raising the threshold to 0.5%).



## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Address some of the concerns raised from https://github.com/checkr/flagr/issues/464

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
unit tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.