### PR TITLE
Add support for Postgres 13.x

### DIFF
--- a/docker-compose.kafka.yml
+++ b/docker-compose.kafka.yml
@@ -19,7 +19,7 @@ mysql8:
     - "18101:3306"
 
 postgres:
-  image: postgres:9
+  image: postgres:13
   container_name: flagr-postgres
   environment:
     POSTGRES_PASSWORD: "test"

--- a/integration_tests/docker-compose.yml
+++ b/integration_tests/docker-compose.yml
@@ -20,9 +20,17 @@ services:
       MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
       MYSQL_DATABASE: "flagr"
 
-  postgres:
+  postgres13:
+    image: postgres:13
+    container_name: flagr-postgres13
+    environment:
+      POSTGRES_PASSWORD: "test"
+      POSTGRES_USER: "test"
+      POSTGRES_DB: "flagr"
+
+  postgres9:
     image: postgres:9
-    container_name: flagr-postgres
+    container_name: flagr-postgres9
     environment:
       POSTGRES_PASSWORD: "test"
       POSTGRES_USER: "test"
@@ -56,11 +64,18 @@ services:
       FLAGR_DB_DBCONNECTIONSTR: "root:@tcp(mysql8:3306)/flagr?parseTime=true"
     command: sh -c "sleep 15 && ./flagr"
 
-  flagr_with_postgres:
+  flagr_with_postgres9:
     image: flagr_integration_tests
     environment:
       FLAGR_DB_DBDRIVER: "postgres"
-      FLAGR_DB_DBCONNECTIONSTR: "sslmode=disable host=postgres user=test password=test dbname=flagr"
+      FLAGR_DB_DBCONNECTIONSTR: "sslmode=disable host=postgres9 user=test password=test dbname=flagr"
+    command: sh -c "sleep 15 && ./flagr"
+
+  flagr_with_postgres13:
+    image: flagr_integration_tests
+    environment:
+      FLAGR_DB_DBDRIVER: "postgres"
+      FLAGR_DB_DBCONNECTIONSTR: "sslmode=disable host=postgres13 user=test password=test dbname=flagr"
     command: sh -c "sleep 15 && ./flagr"
 
   shakedown:

--- a/integration_tests/test.sh
+++ b/integration_tests/test.sh
@@ -397,7 +397,8 @@ start() {
     start_test flagr_with_sqlite
     start_test flagr_with_mysql
     start_test flagr_with_mysql8
-    start_test flagr_with_postgres
+    start_test flagr_with_postgres9
+    start_test flagr_with_postgres13
 
     # for backward compatibility with checkr/flagr
     start_test checkr_flagr_with_sqlite


### PR DESCRIPTION


## Description
As mentioned here https://github.com/checkr/flagr/issues/466 Postgres
9.6 is deprecated and no longer receiving security patches, therefore,
  we need to start supporting other versions.

For now, we keep testing for pgsql9.6 but also testing for the latest
available version (for production), which seems to be 13.x

Thanks @jnikitin-r7 for the issue


## How Has This Been Tested?

Adding mainly integration testing with different pgsql versions

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.