### PR TITLE
Return 400 when flag.key is not unique

### DIFF
--- a/integration_tests/test.sh
+++ b/integration_tests/test.sh
@@ -44,6 +44,13 @@ step_2_test_crud_flag() {
     contains "$key_1"
 
     ################################################
+    # Test create flag with invalid params
+    ################################################
+    shakedown POST "$flagr_url"/flags -H 'Content-Type:application/json' -d "{\"description\": \"$description_1\", \"key\": \"$key_1\"}"
+    status 400
+    matches '"message":"cannot create flag. UNIQUE constraint failed: flags.key"'
+
+    ################################################
     # Test put flag
     ################################################
     shakedown PUT "$flagr_url"/flags/1 -H 'Content-Type:application/json' -d "{\"description\": \"$description_3\", \"key\": \"$key_3\", \"enabled\": true}"
@@ -75,6 +82,13 @@ step_2_test_crud_flag() {
     shakedown GET "$flagr_url"/flags/entity_types -H 'Content-Type:application/json'
     status 200
     contains 'candidate_resource_id'
+
+    ################################################
+    # Test update flag with invalid params
+    ################################################
+    shakedown PUT "$flagr_url"/flags/2 -H 'Content-Type:application/json' -d "{\"description\": \"$description_1\", \"key\": \"$key_3\"}"
+    status 400
+    matches '"message":"UNIQUE constraint failed: flags.key"'
 
     ################################################
     # Test query flags

--- a/pkg/handler/crud_flag_creation_test.go
+++ b/pkg/handler/crud_flag_creation_test.go
@@ -120,4 +120,20 @@ func TestCrudCreateFlagWithFailures(t *testing.T) {
 		})
 		assert.NotZero(t, res.(*flag.CreateFlagDefault).Payload)
 	})
+
+	t.Run("CreateFlag - Uniqueness Constraint should return 400", func(t *testing.T) {
+		m := "UNIQUE constraint failed: flags.key"
+		db.Error = fmt.Errorf(m)
+		params := flag.CreateFlagParams{
+			Body: &models.CreateFlagRequest{
+				Description: util.StringPtr("Switzerland"),
+				Key:         "ch",
+			},
+		}
+		res = c.CreateFlag(params).(*flag.CreateFlagDefault)
+		expRes := flag.NewCreateFlagDefault(400).WithPayload(ErrorMessage("cannot create flag. %s", m))
+
+		assert.Equal(t, res, expRes)
+		db.Error = nil
+	})
 }


### PR DESCRIPTION
The uniqueness constraint of `flag.key` is a known part of flag. Validation errors that rely on client-logic (uniqueness of a field) is responsibility of the client to implement, thus the server should return a 400-ish (e.g.: 400 Bad Request, 406 Not Acceptable, ...) and not a 500 Internal Server Error, since that is not the case.

More info: #41

## Description

Capture flag uniqueness errors to respond with 400 and not 500 since it is a client-side problem

## Motivation and Context

#41 

## How Has This Been Tested?

Added a test in the controller, but probably not need an integration one...

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


### Updates

This can also happen on `PUT /api/v1/flag/:id Key=AlreadyExistent`.

### TODO


* [x] Add integration tests for invalid POST
* [x] Add integration tests for invalid PUT
* [x] Add unit tests for invalid POST
* [x] Add uni tests for invalid PUT
* [x] Fix POST
* [x] Fix PUT
